### PR TITLE
Fix ship issue endpoint returning 404

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specwright",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specwright",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specwright",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AI-Powered Specification Engine - Transform Ideas into Specs",
   "type": "module",
   "main": "dist/specwright.js",


### PR DESCRIPTION
## Summary
- Fixed the `/api/issues/:projectId/:issueId/ship` endpoint that was returning 404 errors
- The endpoint was checking for `.md` files that no longer exist (issues are now stored in `issues.json`)
- Also fixed the `/api/issues/:projectId/:issueId/prompt` endpoint with the same issue

## Test plan
- [ ] Click "Ship" button on an issue in the task board
- [ ] Verify it no longer returns 404 error
- [ ] Verify the prompt is generated correctly

Fixes WOR-32